### PR TITLE
fix link in Tutorial for Install

### DIFF
--- a/tutorial.markdown
+++ b/tutorial.markdown
@@ -4,7 +4,7 @@ title: Tutorial
 permalink: /tutorial/
 ---
 
-If you don't already have Anansi installed, check out [this page](/install).
+If you don't already have Anansi installed, check out [this page](/anansi/install).
 
 To see which version of Anansi you have, run the following command:
 ```shell


### PR DESCRIPTION
Hi, 
I found this gem, and tried it out and noticed the `install` link is broken on the `tutorial` page.
I think the fix is to prefix it with `/anansi`.